### PR TITLE
feat!: Add dispatch table, increase default pprint width, fixes

### DIFF
--- a/mini_snapshot.py
+++ b/mini_snapshot.py
@@ -20,24 +20,6 @@ class CantUpdateSnapshots(RuntimeError):
     ...
 
 
-def format_obj(obj: object) -> str:
-    if method := getattr(obj, '_format_snapshot_', None):
-        return method()
-    if isinstance(obj, str):
-        # already string, don't repr it to help with snapshot readability
-        # TODO: should be put something in front of this
-        #  e.g. '<str>(' + obj + ')' etc.,
-        #  maybe repr it into a triple-quoted string?
-        return obj
-    try:
-        return pprint.pformat(obj)
-    except TypeError:
-        # TODO: this will never match for classes without __repr__
-        #  as the fallback is to <object at 0x1234...> and the address
-        #  will (almost) never be the same
-        return repr(obj)
-
-
 def _string_is_number(s: str):
     try:
         int(s)
@@ -82,6 +64,35 @@ class SnapshotTestCase(unittest.TestCase):
     _files_cache: dict[str, dict[str, str]]
     _queued_changes: dict[str, dict[str, str]]
     _subtest = None
+
+    format_dispatch = {}
+
+    @classmethod
+    def _lookup_in_dispatch(cls, t: type):
+        if m := cls.format_dispatch.get(t):
+            return m
+        for sup in t.mro():
+            if m := cls.format_dispatch.get(sup):
+                cls.format_dispatch[t] = m  # Cache it so we don't need to walk MRO again.
+                return m
+        return None
+
+    @classmethod
+    def format_obj(cls, obj: object) -> str:
+        if method := cls._lookup_in_dispatch(type(obj)):
+            return method(obj)
+        if method := getattr(obj, '_format_snapshot_', None):
+            return method()
+        if isinstance(obj, str):
+            # already string, don't repr it to help with snapshot readability
+            return obj
+        try:
+            return pprint.pformat(obj, width=120)
+        except TypeError:
+            # TODO: this will never match for classes without __repr__
+            #  as the fallback is to <object at 0x1234...> and the address
+            #  will (almost) never be the same
+            return repr(obj)
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -134,7 +145,7 @@ class SnapshotTestCase(unittest.TestCase):
                               msg: str | None = None):
         SingleSnapshot(
             self, self._allocate_sub_name(name), self.get_opts()
-        ).assert_matches(format_obj(obj), msg)
+        ).assert_matches(self.format_obj(obj), msg)
 
     def get_opts(self) -> 'SnapOptions':
         return SnapOptions(self.update_snapshots, self.longMessage)
@@ -195,12 +206,20 @@ class SnapshotTestCase(unittest.TestCase):
 
     @classmethod
     def write_queued_snapshots(cls):
+        if not cls._queued_changes:
+            return
         cls._make_snaps_dir()
         for path, changes in cls._queued_changes.items():
+            if not changes:
+                continue
             with _open_or_create_rw(path) as f:  # do in one go to reduce chance of racing
-                orig = parse_snap(f.read())  # Use most up-to-date value (no cache)
+                content = f.read()  # Read most up-to-date value (no cache)
+                # Only use .strip() in the condition - whitespace may be part of snapshot
+                orig = parse_snap(content) if content.strip() else {}
                 f.seek(0, os.SEEK_SET)  # go to start
                 format_snap(f, cls._apply_file_changes(orig, changes))
+                # Remove extra garbage that may be left over and not fully overwritten
+                f.truncate()
 
     @classmethod
     def _apply_file_changes(cls, orig: dict[str, str], new: dict[str, str]):


### PR DESCRIPTION
Commits, see [the `programming_lang_2` repo](https://github.com/MarcellPerger1/programming_lang_2/commits/1e9e34557e8d89dae61c6790c09dbb14e0e0b952/test/snapshottest.py?since=2024-10-27&until=2024-11-10):
```
fix(snapshottest): Fix regression when creating new snapshot file
refactor: Remove TODO above repr-ing `str` instances
feat(snapshottest): Add format_dispatch table
feat(snapshottest): Don't create file if there are no snapshots
fix(snapshottest): Truncate leftovers from previous snapshot
fix!(snapshottest): Use higher default width
```